### PR TITLE
access_token 및 refresh_token 인증 인가 리펙토링 

### DIFF
--- a/auth/urls.py
+++ b/auth/urls.py
@@ -1,8 +1,9 @@
 from django.urls import path
 
-from auth.views import SignUpView, SignInView
+from auth.views import SignUpView, SignInView, TokenView
 
 urlpatterns = [
     path('/signup', SignUpView.as_view()),
     path('/signin', SignInView.as_view()),
+    path('/token', TokenView.as_view())
 ]

--- a/auth/views.py
+++ b/auth/views.py
@@ -6,11 +6,8 @@ import jwt
 from django.http            import JsonResponse
 from django.views           import View
 from django.core.exceptions import ValidationError
-from django.core.cache      import cache
 
 from auth.models        import User
-from order.models       import Cart
-from wish_korea.settings import SECRET_KEY, ALGORITHM
 from core.validators     import (
     validate_names,
     validate_email,
@@ -90,12 +87,13 @@ class SignInView(View):
         except User.DoesNotExist:
             return JsonResponse({'message' : 'Ivalid User'}, status = 401)
 
+class TokenView(View):
     def get(self, request):
         try:
-            access_token     = request.headers.get('Authorization')
-            new_access_token = Token('access_token').sign_next_token(access_token)
+            refresh_token = request.headers.get('Authorization')
+            access_token  = Token('access_token').resign_token(refresh_token)
 
-            return JsonResponse({'token' : new_access_token}, status = 200)
+            return JsonResponse({'access_token' : access_token}, status = 200)
 
-        except Exception as e:
-            return JsonResponse({'message' : 'Signin Again'}, status = 400)
+        except jwt.exceptions.ExpiredSignatureError:
+            return JsonResponse({'message' : 'Refresh Token Expire'}, status = 401)

--- a/auth/views.py
+++ b/auth/views.py
@@ -82,11 +82,7 @@ class SignInView(View):
             access_token  = Token('access_token').sign_token(user.id)
             refresh_token = Token('refresh_token').sign_token(user.id)
 
-            cache.set(access_token,refresh_token)
-
-            Cart.objects.filter(id=user.id).delete()
-
-            return JsonResponse({'token' : access_token}, status = 200)
+            return JsonResponse({'access_token' : access_token, 'refresh_token' : refresh_token}, status = 200)
         
         except KeyError:
             return JsonResponse({'message' : 'Key Error'}, status = 400)

--- a/core/token.py
+++ b/core/token.py
@@ -2,16 +2,13 @@ import jwt
 
 from datetime import datetime, timedelta
 
-from django.core.cache import cache
-from django.http       import JsonResponse
-
 from my_settings import SECRET_KEY, REFRESH_TOKEN_SECRET_KEY, ACCESS_TOKEN_ALGORITHM, REFRESH_TOKEN_ALGORITHM
 
 class Token:
     def __init__(self, type):
         self.type    = type
         self.EXPIRES = {
-            'access_token': datetime.utcnow() + timedelta(seconds = 1), 
+            'access_token': datetime.utcnow() + timedelta(hours = 1), 
             'refresh_token': datetime.utcnow() + timedelta(hours = 8)
             }
         self.ALGORITHMS  = {'access_token': ACCESS_TOKEN_ALGORITHM , 'refresh_token': REFRESH_TOKEN_ALGORITHM}
@@ -26,15 +23,10 @@ class Token:
 
         return token
 
-    def sign_token_again(self, access_token):
-        try:
-            refresh_token            = cache.get(access_token)
+    def resign_token(self, refresh_token):
             REFRESH_TOKEN_ALGORITHM  = self.ALGORITHMS['refresh_token']
             REFRESH_TOKEN_SECRET_KEY = self.SECRET_KEYS['refresh_token']
             user_id                  = jwt.decode(refresh_token, REFRESH_TOKEN_SECRET_KEY, REFRESH_TOKEN_ALGORITHM)['id']
             access_token             = self.sign_token(user_id)
-
+    
             return access_token
-
-        except jwt.exceptions.ExpiredSignatureError:
-            raise Exception()

--- a/core/token_decorators.py
+++ b/core/token_decorators.py
@@ -1,11 +1,11 @@
 import jwt
 
-from django.http  import JsonResponse, HttpResponseRedirect
+from django.http  import JsonResponse
 
 from auth.models       import User
 from wish_korea.settings import SECRET_KEY , ALGORITHM
 
-def token_decorator(func):
+def verify_token(func):
     def wrapper(self,request,*args,**kwargs):
         try:
             access_token = request.headers.get("Authorization",None)
@@ -22,6 +22,6 @@ def token_decorator(func):
             return JsonResponse({'message' : 'INVALID_USER'}, status=401)
 
         except jwt.exceptions.ExpiredSignatureError:
-            return HttpResponseRedirect('/users/signin')
+            return JsonResponse({'message' : 'Expire Access Token'}, status = 401)
             
     return wrapper

--- a/order/views.py
+++ b/order/views.py
@@ -4,11 +4,11 @@ from django.http                import JsonResponse
 from django.views               import View
 from django.db.models           import Sum
 
-from order.models         import Cart
-from core.token_decorators import token_decorator
+from order.models          import Cart
+from core.token_decorators import verify_token
 
 class CartView(View):
-    @token_decorator
+    @verify_token
     def patch(self, requset):
         try:
             data                = json.loads(requset.body)
@@ -27,7 +27,7 @@ class CartView(View):
             return JsonResponse({'message' : 'Invalid Cart'}, status = 404)
 
 class CartsView(View):
-    @token_decorator
+    @verify_token
     def get(self, request):
         user   = request.user
         carts  = Cart.objects.filter(user = user)\
@@ -51,7 +51,7 @@ class CartsView(View):
             
         return JsonResponse({'result' : result}, status = 200)
 
-    @token_decorator
+    @verify_token
     def post(self, request):
         try:
             items = json.loads(request.body)['items']
@@ -70,7 +70,7 @@ class CartsView(View):
         except KeyError:
             return JsonResponse({'message' : 'Key Error'}, status = 400)
 
-    @token_decorator
+    @verify_token
     def delete(self, request):
         cart_ids   = request.GET.getlist('cart_id')
         carts      = Cart.objects.filter(id__in = cart_ids)


### PR DESCRIPTION
기존의 redis로 관리하던 방식의 리프레시 토큰을 클라이언트 딴에서 보관하도록 변경

## :: 구현 사항 설명 (작업한 내용을 상세하게 기록합니다.)

1. Access토큰 만료시 Redirect가 아닌 401 에러 반환

2. Token 재발급 API End-Point생성

3. Token 재발급 메서드명 resign_token으로 변경

4. 토큰 검증 데코레이터 함수명 변경

5. redis 캐시 관련 로직 제거

6. 로그인시 장바구니 삭제 기능 제거

## :: 특이 사항

-
